### PR TITLE
Errors when a window has a x or y negative value.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@ fn parse_row(row: &str) -> Window {
         .collect::<Vec<&str>>();
 
     let (x, y, w, h) = (
-        columns[2].parse::<u16>().unwrap(),
-        columns[3].parse::<u16>().unwrap(),
+        columns[2].parse::<i16>().unwrap(),
+        columns[3].parse::<i16>().unwrap(),
         columns[4].parse::<u16>().unwrap(),
         columns[5].parse::<u16>().unwrap(),
     );

--- a/src/transformation.rs
+++ b/src/transformation.rs
@@ -4,14 +4,14 @@ use std::fmt;
 #[derive(Debug)]
 pub struct Transformation {
     pub gravity: u16,
-    pub x: u16,
-    pub y: u16,
+    pub x: i16,
+    pub y: i16,
     pub width: u16,
     pub height: u16,
 }
 
 impl Transformation {
-    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Transformation {
+    pub fn new(x: i16, y: i16, width: u16, height: u16) -> Transformation {
         Transformation {
             gravity: 0,
             x,


### PR DESCRIPTION
![wmctrl-sample](https://user-images.githubusercontent.com/24793099/75610502-8c020f80-5b09-11ea-98ee-7d247f5ddf41.png)
 
Hi @Treborium,

I faced problems using the project with windows with negative x or y values.

I changed the type to i16.

Cheers