### PR TITLE
Add `get_current_desktop_name` to `desktop`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ version = "0.1.8"
 authors = ["Robert Fuchs <RobertFuchs97@gmail.com>"]
 edition = "2018"
 
-# This is a fork of Robert's WMCTRL Wrapper, mainly aimed at adding additional functionality.
-# https://github.com/dev11n/rust-wmctrl
-
 [lib]
 name = "wmctrl"
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ version = "0.1.8"
 authors = ["Robert Fuchs <RobertFuchs97@gmail.com>"]
 edition = "2018"
 
+# This is a fork of Robert's WMCTRL Wrapper, mainly aimed at adding additional functionality.
+# https://github.com/dev11n/rust-wmctrl
+
 [lib]
 name = "wmctrl"
 path = "src/lib.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-regex = "1.3.4"
+regex = "1.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,9 @@ edition = "2018"
 name = "wmctrl"
 path = "src/lib.rs"
 
+#[[bin]]
+#name = "wmctrl"
+#path = "src/lib.rs"
+
 [dependencies]
 regex = "1.5.6"

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -42,7 +42,7 @@ pub fn set_desktop_count(count: u8) -> Output {
 }
 
 /// Get the currently active Desktop
-pub fn get_current_desktop() -> i32 {
+pub fn get_current_desktop() -> String {
     let output = String::from_utf8(list_desktops().stdout).unwrap();
 
     let columns = output
@@ -53,8 +53,7 @@ pub fn get_current_desktop() -> i32 {
         .filter(|column| !column.is_empty())
         .collect::<Vec<&str>>();
 
-    // Parse the string to an integer.
-    String::from(columns[0]).parse().unwrap()
+    String::from(columns[0])
 }
 
 // Get the name of the currently active Desktop

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -68,5 +68,5 @@ pub fn get_current_desktop_name() -> String {
         .filter(|column| !column.is_empty())
         .collect::<Vec<&str>>();
 
-    String::from(columns[14])
+    String::from(columns[8])
 }

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -42,7 +42,7 @@ pub fn set_desktop_count(count: u8) -> Output {
 }
 
 /// Get the currently active Desktop
-pub fn get_current_desktop() -> String {
+pub fn get_current_desktop() -> i32 {
     let output = String::from_utf8(list_desktops().stdout).unwrap();
 
     let columns = output
@@ -53,5 +53,21 @@ pub fn get_current_desktop() -> String {
         .filter(|column| !column.is_empty())
         .collect::<Vec<&str>>();
 
-    String::from(columns[0])
+    // Parse the string to an integer.
+    String::from(columns[0]).parse().unwrap()
+}
+
+// Get the name of the currently active Desktop
+pub fn get_current_desktop_name() -> String {
+    let output = String::from_utf8(list_desktops().stdout).unwrap();
+
+    let columns = output
+        .lines()
+        .find(|line| line.contains('*'))
+        .unwrap()
+        .split(' ')
+        .filter(|column| !column.is_empty())
+        .collect::<Vec<&str>>();
+
+    String::from(columns[14])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub fn help() -> Output {
     wmctrl("-h")
 }
 
+// /// Startup function if [bin] is uncommented inside of Cargo.toml.
+// pub fn main() { }
+
 /// Get windows managed by the window manager
 ///
 /// This function is the equivalent of `wmctrl -l -G`.


### PR DESCRIPTION
## Example
```rust
println!("Current workspace is {}", wmctrl::desktop::get_current_desktop_name());